### PR TITLE
fix: update pagination route and parameter naming in EventController

### DIFF
--- a/src/infrastructure/controller/events.controller.ts
+++ b/src/infrastructure/controller/events.controller.ts
@@ -130,15 +130,15 @@ export class EventController {
     async getPaginated(req: Request, res: Response) {
         try {
             const page = Number(req.query.page) || 1;
-            const limit = Number(req.query.limit) || 10;
+            const items = Number(req.query.limit) || 10;
 
-            if (page < 1 || limit < 1) {
+            if (page < 1 || items < 1) {
                 return res.status(400).json({ 
-                    message: "Invalid pagination parameters. Page and limit must be greater than 0." 
+                    message: "Invalid pagination parameters. Page and items must be greater than 0." 
                 });
             }
 
-            const result = await this.eventService.getPaginated(page - 1, limit);
+            const result = await this.eventService.getPaginated(page - 1, items);
             res.status(200).json(result);
         } catch (error) {
             res.status(400).json({ message: error.message });

--- a/src/routes/events.routes.ts
+++ b/src/routes/events.routes.ts
@@ -15,7 +15,7 @@ export class EventsRoute {
     private initializeRoutes(): void {
         this.router.get('/', (req, res) => this.eventController.getAllEvents(req, res));
         this.router.get('/active', (req, res) => this.eventController.getActiveEvents(req, res));
-        this.router.post('/paginated', this.eventController.getPaginated.bind(this.eventController));
+        this.router.get('/paginated', this.eventController.getPaginated.bind(this.eventController));
         this.router.get('/name/:name', (req, res) => this.eventController.getEventByName(req, res));
         this.router.get('/start-date', (req, res) => this.eventController.getEventsByStartDate(req, res));
         this.router.get('/sale-start', (req, res) => this.eventController.getEventsBySaleStart(req, res));


### PR DESCRIPTION
- Changed the HTTP method for the paginated route from POST to GET for consistency with RESTful practices.
- Renamed the 'limit' parameter to 'items' in the EventController to improve clarity in pagination logic.